### PR TITLE
bug(eval): fix potential division by zero in progress update logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'apps/eval/**'
+      - 'packages/db/**'
       - '.github/workflows/release.yml'
 
 permissions:

--- a/apps/eval/src/eval/index.ts
+++ b/apps/eval/src/eval/index.ts
@@ -183,6 +183,7 @@ export class Eval<Input, Expected, Output, Score extends BaseScore> {
           // Update progress in database less frequently
           if (
             this.#currentEvalRun !== null &&
+            progressUpdateInterval > 0 &&
             (completed % progressUpdateInterval === 0 ||
               completed === data.length)
           ) {


### PR DESCRIPTION
## Summary
- Fix potential division by zero in progress update logic when data.length < 20
- Add safety check for `progressUpdateInterval > 0` before modulo operation
- Also fix release workflow path filter to include `packages/db/**` for proper npm publish triggers

## Test plan
- [x] Verify semantic-release configuration recognizes `bug(eval)` scope for patch releases
- [x] Check that workflow path filter now includes database package changes
- [ ] Confirm npm publish workflow triggers when this PR is merged to main

This PR tests the fixed release workflow that should now properly trigger npm publish for eval package changes.

🤖 Generated with [Claude Code](https://claude.ai/code)